### PR TITLE
Add Support for EKS

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,52 @@
+name: Test
+
+on: [pull_request]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: src/github.com/kubenav/bind
+
+      - name: Setup Go 1.13
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+
+      - name: Set GOPATH
+        run: |
+          echo "##[set-env name=GOPATH;]$(dirname $GITHUB_WORKSPACE)/bind"
+          echo "##[add-path]$(dirname $GITHUB_WORKSPACE)/bind/bin"
+        shell: bash
+
+      - name: Install Dependencies
+        run: |
+          cd $GOPATH/src/github.com/kubenav/bind
+          make dependencies
+
+      - name: Generate Bindings (Android)
+        # We must build the Android bindings on Ubuntu,
+        # because the macOS used for GitHub Actions contains an outdated NDK version.
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          cd $GOPATH/src/github.com/kubenav/bind
+          gomobile init
+          make bindings-android
+
+      - name: Generate Bindings (iOS)
+        if: matrix.os == 'macos-latest'
+        # We must unset the ANDROID_HOME and ANDROID_NDK_HOME environment variables,
+        # otherwise gomobile tries to generate the bindings for Android.
+        run: |
+          cd $GOPATH/src/github.com/kubenav/bind
+          unset ANDROID_HOME
+          unset ANDROID_NDK_HOME
+          gomobile init
+          make bindings-ios

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ bindings-ios:
 
 dependencies:
 	GO111MODULE=off go get -u golang.org/x/mobile/cmd/gomobile
+	GO111MODULE=off go get -u github.com/aws/aws-sdk-go/...
 
 release-major:
 	$(eval MAJORVERSION=$(shell git describe --tags --abbrev=0 | sed s/v// | awk -F. '{print $$1+1".0.0"}'))

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -50,3 +50,30 @@ func TestDoNonexistingResource(t *testing.T) {
 
 	t.Logf(err.Error())
 }
+
+func TestAWSGetClusters(t *testing.T) {
+	accessKeyId := os.Getenv("AWS_ACCESS_KEY_ID")
+	secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	region := os.Getenv("AWS_REGION")
+
+	data, err := AWSGetClusters(accessKeyId, secretAccessKey, region)
+	if err != nil {
+		t.Errorf("Could not get clusters: %s", err.Error())
+	}
+
+	t.Logf(data)
+}
+
+func TestAWSGetToken(t *testing.T) {
+	accessKeyId := os.Getenv("AWS_ACCESS_KEY_ID")
+	secretAccessKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	region := os.Getenv("AWS_REGION")
+	clusterID := os.Getenv("AWS_CLUSTER_ID")
+
+	data, err := AWSGetToken(accessKeyId, secretAccessKey, region, clusterID)
+	if err != nil {
+		t.Errorf("Could not get token: %s", err.Error())
+	}
+
+	t.Logf(data)
+}


### PR DESCRIPTION
- Add a new GitHub Actions workflow to test the generation of the bindings for Android and iOS on each PR.
- Add support for EKS via two new functions:
  - `AWSGetClusters`: returns all EKS clusters. This returns the name, server and certificate authority data for the Kubernetes cluster.
  - `AWSGetToken`: returns a bearer token for Kubernetes API requests. This implements the `aws-iam-authenticator token -i clusterID` function from the generated kubeconfig via AWS cli.