### PR TITLE
Add Support for Azure AKS Clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ bindings-ios:
 dependencies:
 	GO111MODULE=off go get -u golang.org/x/mobile/cmd/gomobile
 	GO111MODULE=off go get -u github.com/aws/aws-sdk-go/...
+	GO111MODULE=off go get -u github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-01-01/containerservice
+	GO111MODULE=off go get -u gopkg.in/yaml.v2
 
 release-major:
 	$(eval MAJORVERSION=$(shell git describe --tags --abbrev=0 | sed s/v// | awk -F. '{print $$1+1".0.0"}'))

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -77,3 +77,18 @@ func TestAWSGetToken(t *testing.T) {
 
 	t.Logf(data)
 }
+
+func TestAzureGetClusters(t *testing.T) {
+	subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
+	clientID := os.Getenv("AZURE_CLIENT_ID")
+	clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
+	tenantID := os.Getenv("AZURE_TENANT_ID")
+	resourceGroupName := os.Getenv("AZURE_RESOURCE_GROUP_NAME")
+
+	data, err := AzureGetClusters(subscriptionID, clientID, clientSecret, tenantID, resourceGroupName, true)
+	if err != nil {
+		t.Errorf("Could not get clusters: %s", err.Error())
+	}
+
+	t.Logf(data)
+}


### PR DESCRIPTION
Add a new function for Azure support. The user have to provide his credentials for Azure and the function returns the Kubeconfig for all configured cluster.