### PR TITLE
Add support for OIDC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ dependencies:
 	GO111MODULE=off go get -u golang.org/x/mobile/cmd/gomobile
 	GO111MODULE=off go get -u github.com/aws/aws-sdk-go/...
 	GO111MODULE=off go get -u github.com/Azure/azure-sdk-for-go/services/containerservice/mgmt/2020-01-01/containerservice
+	GO111MODULE=off go get -u github.com/coreos/go-oidc
+	GO111MODULE=off go get -u golang.org/x/oauth2
 	GO111MODULE=off go get -u gopkg.in/yaml.v2
 
 release-major:

--- a/request/request_test.go
+++ b/request/request_test.go
@@ -92,3 +92,47 @@ func TestAzureGetClusters(t *testing.T) {
 
 	t.Logf(data)
 }
+
+func TestOIDCGetLink(t *testing.T) {
+	discoveryURL := os.Getenv("OIDC_DISCOVERY_URL")
+	clientID := os.Getenv("OIDC_CLIENT_ID")
+	clientSecret := os.Getenv("OIDC_CLIENT_SECRET")
+	redirectURL := os.Getenv("OIDC_REDIRECT_URL")
+
+	data, err := OIDCGetLink(discoveryURL, clientID, clientSecret, redirectURL)
+	if err != nil {
+		t.Errorf("Could not get OIDC link: %s", err.Error())
+	}
+
+	t.Logf(data)
+}
+
+func TestOIDCGetRefreshToken(t *testing.T) {
+	discoveryURL := os.Getenv("OIDC_DISCOVERY_URL")
+	clientID := os.Getenv("OIDC_CLIENT_ID")
+	clientSecret := os.Getenv("OIDC_CLIENT_SECRET")
+	redirectURL := os.Getenv("OIDC_REDIRECT_URL")
+	code := os.Getenv("OIDC_CODE")
+
+	data, err := OIDCGetRefreshToken(discoveryURL, clientID, clientSecret, redirectURL, code)
+	if err != nil {
+		t.Errorf("Could not get OIDC refresh token: %s", err.Error())
+	}
+
+	t.Logf(data)
+}
+
+func TestOIDCGetAccessToken(t *testing.T) {
+	discoveryURL := os.Getenv("OIDC_DISCOVERY_URL")
+	clientID := os.Getenv("OIDC_CLIENT_ID")
+	clientSecret := os.Getenv("OIDC_CLIENT_SECRET")
+	redirectURL := os.Getenv("OIDC_REDIRECT_URL")
+	refreshToken := os.Getenv("OIDC_REFRESH_TOKEN")
+
+	data, err := OIDCGetAccessToken(discoveryURL, clientID, clientSecret, redirectURL, refreshToken)
+	if err != nil {
+		t.Errorf("Could not get OIDC access token: %s", err.Error())
+	}
+
+	t.Logf(data)
+}


### PR DESCRIPTION
Add support for OIDC:

- Create login link for the given OIDC provider
- Get `refresh_token` for the returned `code`
- Refresh the `id_token` with a given `refresh_token`